### PR TITLE
restore missing puff_map script mapping test

### DIFF
--- a/foodx_devops_tools/pipeline_config/pipeline.py
+++ b/foodx_devops_tools/pipeline_config/pipeline.py
@@ -504,7 +504,7 @@ class PipelineConfiguration(pydantic.BaseModel):
                         frame_step_names = {
                             x.name
                             for x in application_data.steps
-                            if hasattr(x, "name")
+                            if hasattr(x, "name") and hasattr(x, "arm_file")
                         }
                         if frame_step_names != set(subscription_data.keys()):
                             message = (

--- a/tests/ci/unit_tests/pipeline_config/pipeline/test_frames_puff_map.py
+++ b/tests/ci/unit_tests/pipeline_config/pipeline/test_frames_puff_map.py
@@ -499,3 +499,49 @@ def test_missing_application_step_raises2(mock_loads, mock_results):
         match=r"Application step name mismatch between frames and puff map",
     ):
         PipelineConfiguration.from_files(MOCK_PATHS, MOCK_SECRET)
+
+
+def test_script_missing_puff_map_ok(mock_loads, mock_results):
+    mock_results.frames = FramesDefinition.parse_obj(
+        {
+            "frames": {
+                "frames": {
+                    "f1": {
+                        "applications": {
+                            "a1": {
+                                "steps": [
+                                    {
+                                        "name": "my-script",
+                                        "script": "do something",
+                                    },
+                                ],
+                            },
+                        },
+                        "folder": "some/path",
+                    },
+                },
+            },
+        }
+    ).frames
+    mock_results.puff_map = PuffMapGeneratedFiles.parse_obj(
+        {
+            "puff_map": {
+                "frames": {
+                    "f1": {
+                        "applications": {
+                            "a1": {
+                                "arm_parameters_files": {
+                                    "r1": {
+                                        "sys1_c1_r1a": dict(),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    ).puff_map
+    mock_loads(mock_results)
+
+    PipelineConfiguration.from_files(MOCK_PATHS, MOCK_SECRET)


### PR DESCRIPTION
fixes https://github.com/Food-X-Technologies/foodx_devops_tools/issues/122

not sure what happened, but at least one critical unit test was removed (i remember writing the test(s)) such that the puff_map check was incorrect in the presence of the script application step. restored the test that detects the problem and the code that fixes it.